### PR TITLE
Add cloud agent wrappers, teams feature, and learn-more links

### DIFF
--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -1,4 +1,5 @@
 ---
+const baseUrl = import.meta.env.BASE_URL;
 ---
 
 <section>
@@ -11,28 +12,39 @@
       <details class="faq-item">
         <summary>Is my data really private?</summary>
         <div class="faq-body">
-          <p>When using local models, yes. High Vibes supports local-first inference:</p>
+          <p>It depends on which agents you use:</p>
           <ul>
-            <li><strong>Local model execution</strong> — models run on your hardware via Ollama, vLLM, or LM Studio.</li>
-            <li><strong>No telemetry during inference</strong> — your prompts and responses stay on your machine when using local agents.</li>
-            <li><strong>Local storage</strong> — conversations and settings are stored on your device.</li>
+            <li><strong>Local agents</strong> (Ollama, vLLM, LM Studio) — your code and prompts stay entirely on your machine. Nothing is sent over the network.</li>
+            <li><strong>Cloud agents</strong> (Claude Code, Gemini CLI, Codex, OpenCode) — your prompts are sent to the respective cloud provider (Anthropic, Google, OpenAI, etc.) for processing. These agents require network access by design.</li>
+            <li><strong>Remote / Teams mode</strong> — session data is routed through our relay and stored on our servers so your team can access shared sessions and metrics.</li>
           </ul>
-          <p>Premium features like cloud model fallback and remote access do use the network, but only when you explicitly opt in.</p>
-          <p><a href={`${import.meta.env.BASE_URL}privacy/`} class="faq-link">Read our full privacy architecture →</a></p>
+          <p>You always choose which agent to use and whether to enable remote or teams mode.</p>
+          <p><a href={`${baseUrl}privacy/`} class="faq-link">Read our full privacy architecture →</a></p>
+        </div>
+      </details>
+
+      <details class="faq-item">
+        <summary>What agents can I use?</summary>
+        <div class="faq-body">
+          <p>High Vibes wraps multiple coding agents through a single interface:</p>
+          <ul>
+            <li><strong>Local agents</strong> — any model supported by Ollama, vLLM, or LM Studio (Llama 3, Mistral, Phi-3, Gemma, and hundreds more).</li>
+            <li><strong>Cloud agents (Premium)</strong> — Claude Code, Gemini CLI, Codex, and OpenCode. These connect to their respective cloud providers.</li>
+          </ul>
         </div>
       </details>
 
       <details class="faq-item">
         <summary>What happens after the trial?</summary>
         <div class="faq-body">
-          <p>After your trial expires, you keep full access to local coding agents (Ollama, vLLM, LM Studio) on the free tier. The free tier is ad-supported with a brief interstitial on app open (at most once per hour). Premium features — voice input, remote access, cloud model fallback, and metrics — require a paid subscription.</p>
+          <p>After your trial expires, you keep full access to local coding agents on the free tier. The free tier is ad-supported with a brief interstitial on app open (at most once per hour). Premium features — cloud agents, voice input, remote access, and teams — require a paid subscription.</p>
         </div>
       </details>
 
       <details class="faq-item">
-        <summary>What models can I use?</summary>
+        <summary>What is Teams mode?</summary>
         <div class="faq-body">
-          <p>Any model supported by Ollama, vLLM, or LM Studio — including Llama 3, Mistral, Phi-3, Gemma, and hundreds more. Premium users can also access cloud models like GPT-4 and Claude as a fallback.</p>
+          <p>Teams is a Premium feature that lets your organisation collaborate through High Vibes. It includes shared agent sessions, team-wide metrics and usage insights, and centralised configuration. Session data in Teams mode is stored on our servers so all team members can access it.</p>
         </div>
       </details>
 
@@ -41,9 +53,9 @@
         <div class="faq-body">
           <p>High Vibes runs across three surfaces:</p>
           <ul>
-            <li><strong>Desktop service</strong> — a Python-based orchestration service that manages your local coding agents.</li>
+            <li><strong>Desktop service</strong> — a Python-based orchestration service that manages your coding agents.</li>
             <li><strong>Mobile app</strong> — a React Native app for voice-first interaction with your agents on the go.</li>
-            <li><strong>Web dashboard</strong> — view your session history and metrics (no live sessions).</li>
+            <li><strong>Web dashboard</strong> — view your session history and metrics (no live sessions). Teams mode adds shared dashboards.</li>
           </ul>
         </div>
       </details>
@@ -51,14 +63,14 @@
       <details class="faq-item">
         <summary>What hardware do I need?</summary>
         <div class="faq-body">
-          <p>A modern Mac (M1+), Linux, or Windows machine with at least 8GB RAM. Smaller models like Phi-3 run well on modest hardware; larger models benefit from 16GB+ and a discrete GPU.</p>
+          <p>For local agents: a modern Mac (M1+), Linux, or Windows machine with at least 8GB RAM. Smaller models like Phi-3 run well on modest hardware; larger models benefit from 16GB+ and a discrete GPU. Cloud agents have no special hardware requirements beyond a network connection.</p>
         </div>
       </details>
 
       <details class="faq-item">
-        <summary>How is this different from ChatGPT/Claude?</summary>
+        <summary>How is this different from using Claude Code / Gemini CLI directly?</summary>
         <div class="faq-body">
-          <p>Those are cloud-only services. High Vibes is a local-first interface for coding agents — your code stays on your machine during local inference. It also gives you a mobile app, voice input (Premium), and the flexibility to choose between local and cloud models.</p>
+          <p>High Vibes wraps those agents and adds a unified mobile-first interface, voice input, remote access to your desktop from your phone, and the ability to switch between local and cloud agents seamlessly. Teams mode adds shared sessions and metrics across your organisation.</p>
         </div>
       </details>
     </div>

--- a/src/components/FeaturePillars.astro
+++ b/src/components/FeaturePillars.astro
@@ -1,18 +1,22 @@
 ---
+const baseUrl = import.meta.env.BASE_URL;
+
 const features = [
   {
     id: 'privacy',
     icon: '🔒',
     title: 'Local-First Privacy',
     description: 'Run coding agents locally with Ollama, vLLM, or LM Studio. Your code and prompts stay on your machine during local inference.',
-    link: `${import.meta.env.BASE_URL}privacy/`,
+    link: `${baseUrl}privacy/`,
     linkText: 'Learn more →',
   },
   {
-    id: 'multi-model',
+    id: 'multi-agent',
     icon: '🧠',
-    title: 'Multi-Model Support',
-    description: 'Switch between Ollama, vLLM, LM Studio, and more. Use the right model for every coding task.',
+    title: 'Multi-Agent Support',
+    description: 'One interface for all your coding agents — Claude Code, Gemini CLI, Codex, OpenCode, plus local models via Ollama, vLLM, and LM Studio.',
+    link: '#pricing',
+    linkText: 'Learn more →',
   },
   {
     id: 'voice',
@@ -20,6 +24,8 @@ const features = [
     title: 'Voice Interaction',
     badge: 'Premium',
     description: 'Talk to your coding agents naturally with voice input. Describe what you want to build and let the agent handle the rest.',
+    link: '#pricing',
+    linkText: 'Learn more →',
   },
   {
     id: 'remote',
@@ -27,6 +33,25 @@ const features = [
     title: 'Remote Access',
     badge: 'Premium',
     description: 'Access your coding agents from anywhere. Sign in to connect remotely to your desktop service via our secure relay.',
+    link: '#pricing',
+    linkText: 'Learn more →',
+  },
+  {
+    id: 'teams',
+    icon: '👥',
+    title: 'Teams',
+    badge: 'Premium',
+    description: 'Collaborate with your team — shared agent sessions, team-wide metrics, and centralised configuration across your organisation.',
+    link: '#pricing',
+    linkText: 'Learn more →',
+  },
+  {
+    id: 'dashboard',
+    icon: '📊',
+    title: 'Web Dashboard',
+    description: 'Review your session history and metrics from any browser. Teams mode adds shared dashboards and usage insights across your organisation.',
+    link: '#pricing',
+    linkText: 'Learn more →',
   },
 ];
 ---

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -5,12 +5,12 @@
   <div class="container">
     <div class="pill-row">
       <a href="#privacy" class="pill mono">Local-First</a>
-      <a href="#features" class="pill mono">Multi-Model</a>
-      <a href="#features" class="pill mono">Voice</a>
-      <a href="#features" class="pill mono">Mobile + Desktop</a>
+      <a href="#multi-agent" class="pill mono">Multi-Agent</a>
+      <a href="#voice" class="pill mono">Voice</a>
+      <a href="#teams" class="pill mono">Teams</a>
     </div>
     <h1>Voice-first coding agent <span class="text-gradient">that just works.</span></h1>
-    <p class="subtitle">A mobile-first, voice-enabled interface for multiple coding agents. Run local models on your machine with Ollama, vLLM, and LM Studio — or connect to the cloud with Premium.</p>
+    <p class="subtitle">A mobile-first, voice-enabled interface for your favourite coding agents — Claude Code, Gemini CLI, Codex, OpenCode, and local models via Ollama, vLLM, and LM Studio.</p>
     <div class="cta-group">
       <a href="#quickstart" class="btn btn-primary">Install</a>
       <a href="#pricing" class="btn btn-secondary">Pricing &rarr;</a>

--- a/src/components/TierOverview.astro
+++ b/src/components/TierOverview.astro
@@ -5,7 +5,7 @@ const tiers = [
     price: '$0',
     description: 'Local coding agents after trial',
     features: [
-      'Local model usage (Ollama, vLLM, LM Studio)',
+      'Local agents (Ollama, vLLM, LM Studio)',
       'Desktop service',
       'Mobile app (ad-supported)',
       'Web dashboard (history & metrics)',
@@ -18,14 +18,14 @@ const tiers = [
   {
     name: 'Premium',
     price: '$12/mo',
-    description: 'Full power, everywhere',
+    description: 'Cloud agents, voice, remote & teams',
     features: [
       'Everything in Free, ad-free',
+      'Cloud agents (Claude Code, Gemini CLI, Codex, OpenCode)',
       'Voice input',
       'Remote access via relay',
-      'Cloud model fallback (GPT-4, Claude)',
+      'Teams — shared sessions & team metrics',
       'Advanced workflow automations',
-      'Metrics & analytics',
       'Priority support',
     ],
     cta: 'Coming Soon',
@@ -39,7 +39,7 @@ const tiers = [
   <div class="container">
     <div class="section-heading reveal">
       <h2>Simple, honest pricing</h2>
-      <p>Start with a free trial. Keep local agents free forever, or upgrade for voice, remote access, and cloud models.</p>
+      <p>Start with a free trial. Keep local agents free forever, or upgrade for cloud agents, voice, remote access, and teams.</p>
     </div>
 
     <div class="tier-grid stagger">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,19 +3,19 @@ import Layout from '../layouts/Layout.astro';
 import Footer from '../components/Footer.astro';
 ---
 
-<Layout title="Privacy Architecture — High Vibes" description="How High Vibes keeps your code private with local-first inference, transparent network usage, and user-controlled data.">
+<Layout title="Privacy Architecture — High Vibes" description="How High Vibes handles your data across local agents, cloud agents, remote access, and teams mode.">
   <main>
     <section class="privacy-hero">
       <div class="container">
         <h1>Privacy <span class="text-gradient">Architecture</span></h1>
-        <p class="subtitle">High Vibes is built local-first. When you use local agents, your code and prompts never leave your machine.</p>
+        <p class="subtitle">High Vibes supports both local and cloud coding agents. Here's exactly what happens to your data in each mode.</p>
       </div>
     </section>
 
     <section>
       <div class="container content">
         <div class="reveal">
-          <h2>How local inference works</h2>
+          <h2>Local agents — everything stays on your machine</h2>
           <p>When using local coding agents (Ollama, vLLM, LM Studio), every interaction stays on your device.</p>
 
           <div class="diagram mono">
@@ -38,33 +38,60 @@ import Footer from '../components/Footer.astro';
            ╳ No data leaves this boundary
 `}</pre>
           </div>
-        </div>
 
-        <div class="reveal">
-          <h2>What stays local</h2>
           <ul class="check-list do-list">
-            <li>Model inference when using local agents (Ollama, vLLM, LM Studio)</li>
-            <li>Your code, prompts, and agent responses during local sessions</li>
-            <li>Conversation history stored on your device</li>
+            <li>Model inference runs entirely on your hardware</li>
+            <li>Your code, prompts, and responses never leave your machine</li>
+            <li>Conversation history stored locally on your device</li>
             <li>Configuration and settings in user-readable formats</li>
           </ul>
         </div>
 
         <div class="reveal">
-          <h2>When the network is used</h2>
-          <p>High Vibes does use the network in specific scenarios — always transparently:</p>
+          <h2>Cloud agents — data goes to the provider</h2>
+          <p>When using cloud-based coding agents (Claude Code, Gemini CLI, Codex, OpenCode), your prompts and code context are sent to the respective cloud provider for processing.</p>
+
+          <div class="diagram mono">
+            <pre>{`
+┌──────────────────┐         ┌──────────────────────┐
+│   Your Machine   │         │   Cloud Provider     │
+│                  │         │   (Anthropic /        │
+│  ┌────────────┐  │  HTTPS  │    Google / OpenAI)   │
+│  │ Your Input │──┼────────▶│  ┌────────────────┐  │
+│  └────────────┘  │         │  │ Cloud Inference│  │
+│                  │◀────────┼──│                │  │
+│  ┌────────────┐  │         │  └────────────────┘  │
+│  │  Response  │  │         │                      │
+│  └────────────┘  │         └──────────────────────┘
+└──────────────────┘
+`}</pre>
+          </div>
+
+          <p>Each cloud provider has its own privacy policy and data handling practices. High Vibes does not store or intercept cloud agent traffic — it connects you directly to the provider's API.</p>
+        </div>
+
+        <div class="reveal">
+          <h2>Remote access & Teams — what we store</h2>
+          <p>Premium features that route through our infrastructure:</p>
+          <ul class="check-list info-list">
+            <li><strong>Remote access</strong> — session data passes through our relay so you can reach your desktop service from your phone or another device. Requires account sign-in.</li>
+            <li><strong>Teams mode</strong> — session history, team metrics, and shared configuration are stored on our servers so all team members can access them.</li>
+            <li><strong>Web dashboard</strong> — session history and metrics are synced for signed-in users.</li>
+          </ul>
+          <p>These features are always opt-in. If you only use local agents without remote or teams mode, nothing leaves your machine.</p>
+        </div>
+
+        <div class="reveal">
+          <h2>Other network usage</h2>
           <ol>
-            <li><strong>Model downloads</strong> — when you choose to download a new model through Ollama or another provider.</li>
-            <li><strong>Cloud model fallback (Premium)</strong> — Premium users can opt in to send queries to cloud models (GPT-4, Claude, etc.). This is clearly indicated in the UI and never happens without your explicit action.</li>
-            <li><strong>Remote access (Premium)</strong> — Premium users can connect to their desktop service remotely via our relay. This requires account sign-in.</li>
+            <li><strong>Model downloads</strong> — when you choose to download a new local model through Ollama or another provider.</li>
             <li><strong>Ads (Free tier)</strong> — the free tier displays a brief interstitial ad on app open (at most once per hour).</li>
-            <li><strong>Web dashboard</strong> — the web dashboard syncs session history and metrics for signed-in users.</li>
           </ol>
         </div>
 
         <div class="reveal">
           <h2>Your control</h2>
-          <p>You decide what leaves your machine. Local-only usage requires no account and no network access beyond initial model downloads. Premium network features are always opt-in and clearly labeled in the UI.</p>
+          <p>You always choose which agent to use and whether to enable remote access or teams mode. Local-only usage requires no account, no sign-in, and no network access beyond initial model downloads.</p>
         </div>
       </div>
     </section>
@@ -153,6 +180,11 @@ import Footer from '../components/Footer.astro';
   .do-list li::before {
     content: '✓';
     color: #4caf50;
+  }
+
+  .info-list li::before {
+    content: '→';
+    color: var(--purple);
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- **Cloud agent wrappers** — High Vibes wraps Claude Code, Gemini CLI, Codex, and OpenCode (Premium). Updated hero, features, FAQ, pricing, and privacy page to reflect this.
- **Teams feature** — new Premium feature: shared agent sessions, team-wide metrics, centralised config. Added Teams feature card, FAQ entry, pricing line item, and privacy page section explaining server-side data storage in teams mode.
- **Privacy page data distinction** — separate sections with diagrams for local agents (on-device), cloud agents (data sent to provider), and remote/teams mode (data on our servers).
- **Learn more links** — every feature card now has a "Learn more →" link.
- **Hero pills** — "Multi-Agent" and "Teams" replace "Multi-Model" and "Mobile + Desktop".

## Test plan
- [ ] `npm run build` succeeds
- [ ] All 6 feature cards have "Learn more →" links
- [ ] Privacy page shows 3 distinct data-flow sections (local, cloud, remote/teams)
- [ ] FAQ clearly states cloud agents send data to providers
- [ ] Pricing lists cloud agents and teams under Premium
- [ ] Hero pills link to correct anchors (#privacy, #multi-agent, #voice, #teams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)